### PR TITLE
fix concat example?

### DIFF
--- a/examples/concat.eve
+++ b/examples/concat.eve
@@ -1,5 +1,5 @@
 test concat
   greeting = "Hello"
   target = "World"
-  save
+  maintain
     [#div text: "{greeting}, {target}!"]


### PR DESCRIPTION
I don't fully understand the difference between `save` and `maintain`. Nevertheless, `concat` example doesn't work with `save`, but does work with `maintain`.
