### PR TITLE
enable #input-event

### DIFF
--- a/jssrc/renderer.js
+++ b/jssrc/renderer.js
@@ -405,8 +405,8 @@ window.addEventListener("dblclick", function(event) {
 window.addEventListener("input", function(event) {
   let {target} = event;
   if(target.entity) {
-    let objs = [{tags: ["input"], element: target.entity, value: target.value}];
-    // sendEventObjs(objs);
+    let objs = [{tags: ["input-event"], element: target.entity, value: target.value}];
+    sendEventObjs(objs);
   }
 });
 


### PR DESCRIPTION
I needed `input` event to build search-as-you-type box.

I'm not sure about the name I've chosen (`#input-event`), because `#input` event conflicts with `#input` html element.
